### PR TITLE
Ignore web finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install -r test-requirements.txt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,10 @@ http://localhost:8000/whatever provided that *whatever* is not an integer.
 
 Version History
 ---------------
+* `0.4.0`_ (16-Dec-2015)
+
+  - Ignore web.Finish exceptions
+
 * `0.3.0`_ (13-Jul-2015)
 
   - Add ``sprockets.mixins.sentry.SentryMixin.sentry_extra``
@@ -67,6 +71,7 @@ License
 .. _0.1.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/e01c264...0.1.0
 .. _0.2.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.1.0...0.2.0
 .. _0.3.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.2.0...0.3.0
+.. _0.4.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.3.0...0.4.0
 
 .. |Version| image:: https://badge.fury.io/py/sprockets.mixins.sentry.svg?
    :target: http://badge.fury.io/py/sprockets.mixins.sentry

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (3, 0):
 
 setuptools.setup(
     name='sprockets.mixins.sentry',
-    version='0.3.0',
+    version='0.4.0',
     description='A RequestHandler mixin for sending exceptions to Sentry',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     url='https://github.com/sprockets/sprockets.mixins.sentry.git',

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -4,7 +4,7 @@ mixins.sentry
 A RequestHandler mixin for sending exceptions to Sentry
 
 """
-version_info = (0, 3, 0)
+version_info = (0, 4, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -79,7 +79,9 @@ class SentryMixin(object):
         return values
 
     def _handle_request_exception(self, e):
-        if isinstance(e, web.HTTPError) or self.sentry_client is None:
+        if (isinstance(e, web.HTTPError)
+                or isinstance(e, web.Finish)
+                or self.sentry_client is None):
             return super(SentryMixin, self)._handle_request_exception(e)
 
         duration = math.ceil((time.time() - self.request._start_time) * 1000)

--- a/tests.py
+++ b/tests.py
@@ -45,6 +45,8 @@ class TestRequestHandler(sentry.SentryMixin, web.RequestHandler):
             raise RuntimeError('something unexpected')
         if action == 'http-error':
             raise web.HTTPError(500)
+        if action == 'web-finish':
+            raise web.Finish()
         if action == 'add-tags':
             self.sentry_tags['some_tag'] = 'some_value'
             raise RuntimeError
@@ -114,4 +116,8 @@ class ApplicationTests(testing.AsyncHTTPTestCase):
 
     def test_that_http_errors_are_not_reported(self):
         self.fetch('/http-error')
+        self.assertIsNone(self.get_sentry_message())
+
+    def test_that_web_finish_is_not_reported(self):
+        self.fetch('/web-finish')
         self.assertIsNone(self.get_sentry_message())


### PR DESCRIPTION
With this PR, web.Finish exceptions do not generate Sentry alerts.
Also, python 3.5 has been added as a target python version.
