### PR TITLE
Workaround raven defect

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 AWeber Communications
+Copyright (c) 2015-2016 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ templates_path = []
 source_suffix = '.rst'
 master_doc = 'index'
 project = 'sprockets.mixins.sentry'
-copyright = '2015, AWeber Communications'
+copyright = '2016, AWeber Communications'
 version = '.'.join(__version__.split('.')[0:1])
 release = __version__
 if len(version_info) > 3:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,12 @@ http://localhost:8000/whatever provided that *whatever* is not an integer.
 
 Version History
 ---------------
+* `Next Release`_
+
+  - Work around `getsentry/raven-python#735`_
+
+.. _getsentry/raven-python#735: https://github.com/getsentry/raven-python/issues/735
+
 * `0.4.0`_ (16-Dec-2015)
 
   - Ignore web.Finish exceptions
@@ -72,6 +78,7 @@ License
 .. _0.2.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.1.0...0.2.0
 .. _0.3.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.2.0...0.3.0
 .. _0.4.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.3.0...0.4.0
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.4.0...HEAD
 
 .. |Version| image:: https://badge.fury.io/py/sprockets.mixins.sentry.svg?
    :target: http://badge.fury.io/py/sprockets.mixins.sentry

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ http://localhost:8000/whatever provided that *whatever* is not an integer.
 
 Version History
 ---------------
-* `Next Release`_
+* `1.0.0`_
 
   - Work around `getsentry/raven-python#735`_
 
@@ -78,7 +78,8 @@ License
 .. _0.2.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.1.0...0.2.0
 .. _0.3.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.2.0...0.3.0
 .. _0.4.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.3.0...0.4.0
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.4.0...HEAD
+.. _1.0.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.4.0...1.0.0
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.0.0...HEAD
 
 .. |Version| image:: https://badge.fury.io/py/sprockets.mixins.sentry.svg?
    :target: http://badge.fury.io/py/sprockets.mixins.sentry

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (3, 0):
 
 setuptools.setup(
     name='sprockets.mixins.sentry',
-    version='0.4.0',
+    version='1.0.0',
     description='A RequestHandler mixin for sending exceptions to Sentry',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     url='https://github.com/sprockets/sprockets.mixins.sentry.git',
@@ -39,7 +39,7 @@ setuptools.setup(
     author_email='api@aweber.com',
     license='BSD',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -105,7 +105,7 @@ class SentryMixin(object):
 
         if self.sentry_tags:
             kwargs.update({'tags': self.sentry_tags})
-        self.sentry_client.captureException(True, **kwargs)
+        self.sentry_client.captureException(**kwargs)
 
         super(SentryMixin, self)._handle_request_exception(e)
 

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -4,7 +4,7 @@ mixins.sentry
 A RequestHandler mixin for sending exceptions to Sentry
 
 """
-version_info = (0, 4, 0)
+version_info = (1, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 


### PR DESCRIPTION
This PR removes the unnecessary passing of `True` as the `exc_info` parameter of [raven.Client.captureException](https://docs.getsentry.com/hosted/clients/python/api/#raven.Client.captureException).  This caused failures when reporting exceptions due to https://github.com/getsentry/raven-python/issues/735 and, as it turns out, was completely unnecessary anyway.
