### PR TITLE
Fix password matching regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@
 sudo: false
 language: python
 python:
-  - 2.6
   - 2.7
   - pypy
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install -r test-requirements.txt
   - pip install -e .
 script: nosetests

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,9 +34,10 @@ http://localhost:8000/whatever provided that *whatever* is not an integer.
 
 Version History
 ---------------
-* `Next Release`_
+* `1.1.1`_
 
   - Fix password scrubbing in URLs.
+  - Remove support for python 2.6, 3.2, and 3.3
 
 * `1.1.0`_
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,7 +92,8 @@ License
 .. _0.4.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.3.0...0.4.0
 .. _1.0.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.4.0...1.0.0
 .. _1.1.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.0.0...1.1.0
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.1.0...HEAD
+.. _1.1.1: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.1.0...1.1.1
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.1.1...HEAD
 
 .. |Version| image:: https://badge.fury.io/py/sprockets.mixins.sentry.svg?
    :target: http://badge.fury.io/py/sprockets.mixins.sentry

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,10 @@ http://localhost:8000/whatever provided that *whatever* is not an integer.
 
 Version History
 ---------------
+* `Next Release`_
+
+  - Fix password scrubbing in URLs.
+
 * `1.1.0`_
 
   - Move raven client initialization into ``sprockets.mixins.sentry.install``

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ install_requires = read_requirements_file('requirements.txt')
 setup_requires = read_requirements_file('setup-requirements.txt')
 tests_require = read_requirements_file('test-requirements.txt')
 
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
 if sys.version_info < (3, 0):
     tests_require.append('mock')
 
@@ -45,11 +43,8 @@ setuptools.setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (3, 0):
 
 setuptools.setup(
     name='sprockets.mixins.sentry',
-    version='1.1.0',
+    version='1.1.1',
     description='A RequestHandler mixin for sending exceptions to Sentry',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     url='https://github.com/sprockets/sprockets.mixins.sentry.git',

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -29,7 +29,7 @@ SENTRY_CLIENT = 'sentry_client'
 # leniancy to account for poorly formed URLs.  For example, it lets
 # you include braces and other things in the password section.
 URI_RE = re.compile(r"^[\w\+\-]+://"
-                    r"[-a-z0-9!$&'()*+,;=%.]+:"
+                    r"[-a-z0-9._~!$&'()*+,;=%]+:"
                     r"([^@]+)"
                     r"@",
                     re.IGNORECASE)

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -4,7 +4,7 @@ mixins.sentry
 A RequestHandler mixin for sending exceptions to Sentry
 
 """
-version_info = (1, 1, 0)
+version_info = (1, 1, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 
 

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -25,12 +25,12 @@ from tornado import web
 LOGGER = logging.getLogger(__name__)
 SENTRY_CLIENT = 'sentry_client'
 
-# This matches the userinfo production from RFC3986 with a little
-# leniancy -- for example, it does not strictly enforce that `%` is
-# followed by two hex digits.
+# This matches the userinfo production from RFC3986 with some extra
+# leniancy to account for poorly formed URLs.  For example, it lets
+# you include braces and other things in the password section.
 URI_RE = re.compile(r"^[\w\+\-]+://"
-                    r"[-a-z0-9!$&'()*+,;=%]+:"
-                    r"([-a-z0-9!$&'()*+,;=%]+)"
+                    r"[-a-z0-9!$&'()*+,;=%.]+:"
+                    r"([^@]+)"
                     r"@",
                     re.IGNORECASE)
 

--- a/sprockets/mixins/sentry/__init__.py
+++ b/sprockets/mixins/sentry/__init__.py
@@ -24,7 +24,15 @@ from tornado import web
 
 LOGGER = logging.getLogger(__name__)
 SENTRY_CLIENT = 'sentry_client'
-URI_RE = re.compile(r'^[\w\+\-]+://.*:(\w+)@.*')
+
+# This matches the userinfo production from RFC3986 with a little
+# leniancy -- for example, it does not strictly enforce that `%` is
+# followed by two hex digits.
+URI_RE = re.compile(r"^[\w\+\-]+://"
+                    r"[-a-z0-9!$&'()*+,;=%]+:"
+                    r"([-a-z0-9!$&'()*+,;=%]+)"
+                    r"@",
+                    re.IGNORECASE)
 
 _sentry_warning_issued = False
 

--- a/tests.py
+++ b/tests.py
@@ -21,12 +21,20 @@ import tornado
 
 from sprockets.mixins import sentry
 
+# userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
+# unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+# pct-encoded = "%" HEXDIG HEXDIG
+# sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+#             / "*" / "+" / "," / ";" / "="
+
 VALUES = {'PGSQL_DSN': 'postgres://foo:bar@localhost:5432/dbname',
           'RABBITMQ_DSN': 'amqp://sentry:rabbitmq@localhost:5672/%2f',
-          'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets'}
+          'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets',
+          'PGSQL_FOO': "postgres://foo:abc%1E!$&'(*+,;=)'DEF%40@a/foo?q=12"}
 EXPECTATIONS = {'PGSQL_DSN': 'postgres://foo:****@localhost:5432/dbname',
                 'RABBITMQ_DSN': 'amqp://sentry:****@localhost:5672/%2f',
-                'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets'}
+                'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets',
+                'PGSQL_FOO': 'postgres://foo:****@a/foo?q=12'}
 
 os.environ['SENTRY_DSN'] = (
     'https://00000000000000000000000000000000:'

--- a/tests.py
+++ b/tests.py
@@ -30,11 +30,13 @@ from sprockets.mixins import sentry
 VALUES = {'PGSQL_DSN': 'postgres://foo:bar@localhost:5432/dbname',
           'RABBITMQ_DSN': 'amqp://sentry:rabbitmq@localhost:5672/%2f',
           'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets',
-          'PGSQL_FOO': "postgres://foo:abc%1E!$&'(*+,;=)'DEF%40@a/foo?q=12"}
+          'PGSQL_SAFE': "postgres://foo:ab.c%1E!$&'(*+,;=)'DEF%40@a/foo?q=12",
+          'PGSQL_BAD': 'postgres://foo:{22.0/7.0~=3.14}@a/b'}
 EXPECTATIONS = {'PGSQL_DSN': 'postgres://foo:****@localhost:5432/dbname',
                 'RABBITMQ_DSN': 'amqp://sentry:****@localhost:5672/%2f',
                 'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets',
-                'PGSQL_FOO': 'postgres://foo:****@a/foo?q=12'}
+                'PGSQL_SAFE': 'postgres://foo:****@a/foo?q=12',
+                'PGSQL_BAD': 'postgres://foo:****@a/b'}
 
 os.environ['SENTRY_DSN'] = (
     'https://00000000000000000000000000000000:'

--- a/tests.py
+++ b/tests.py
@@ -30,12 +30,13 @@ from sprockets.mixins import sentry
 VALUES = {'PGSQL_DSN': 'postgres://foo:bar@localhost:5432/dbname',
           'RABBITMQ_DSN': 'amqp://sentry:rabbitmq@localhost:5672/%2f',
           'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets',
-          'PGSQL_SAFE': "postgres://foo:ab.c%1E!$&'(*+,;=)'DEF%40@a/foo?q=12",
+          'PGSQL_SAFE': ("postgres://(-a.1_&!~+*$=;):"
+                         "ab.c%1E!$&'(*+,;=)'DEF%40@a/foo?q=12"),
           'PGSQL_BAD': 'postgres://foo:{22.0/7.0~=3.14}@a/b'}
 EXPECTATIONS = {'PGSQL_DSN': 'postgres://foo:****@localhost:5432/dbname',
                 'RABBITMQ_DSN': 'amqp://sentry:****@localhost:5672/%2f',
                 'VIRTUAL_ENV': '/Users/gavinr/Environments/sprockets',
-                'PGSQL_SAFE': 'postgres://foo:****@a/foo?q=12',
+                'PGSQL_SAFE': 'postgres://(-a.1_&!~+*$=;):****@a/foo?q=12',
                 'PGSQL_BAD': 'postgres://foo:****@a/b'}
 
 os.environ['SENTRY_DSN'] = (


### PR DESCRIPTION
The regex used to match passwords in the URL scrubbing was not matching passwords that contained punctuation.  This would leave some passwords in environment variables unscrubbed.