### PR TITLE
add email sanitization processor

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,10 @@ http://localhost:8000/whatever provided that *whatever* is not an integer.
 
 Version History
 ---------------
+* `1.1.2`_
+
+  - Add email sanitization processor
+
 * `1.1.1`_
 
   - Fix password scrubbing in URLs.
@@ -94,7 +98,8 @@ License
 .. _1.0.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/0.4.0...1.0.0
 .. _1.1.0: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.0.0...1.1.0
 .. _1.1.1: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.1.0...1.1.1
-.. _Next Release: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.1.1...HEAD
+.. _1.1.2: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.1.1...1.1.2
+.. _Next Release: https://github.com/sprockets/sprockets.mixins.sentry/compare/1.1.2...HEAD
 
 .. |Version| image:: https://badge.fury.io/py/sprockets.mixins.sentry.svg?
    :target: http://badge.fury.io/py/sprockets.mixins.sentry

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if sys.version_info < (3, 0):
 
 setuptools.setup(
     name='sprockets.mixins.sentry',
-    version='1.1.1',
+    version='1.1.2',
     description='A RequestHandler mixin for sending exceptions to Sentry',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
     url='https://github.com/sprockets/sprockets.mixins.sentry.git',


### PR DESCRIPTION
Remove emails from sentry using a processor.

This uses a regex that gets close to the rfc5322 and substitutes them with a mask. It will not detect percent encoding.

Note, the following request fields are only processed:
https://github.com/getsentry/raven-python/blob/f15c44e6a8031fcaf672a4b7ccd4a28d93cd9da8/raven/processors.py#L117